### PR TITLE
Let it run again by updating dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,11 +9,11 @@
   :min-lein-version "2.7.1"
 
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.clojure/clojurescript "1.9.946"]
+                 [org.clojure/clojurescript "1.10.764"]
                  [org.clojure/core.async  "0.4.474"]
                  [reagent "0.7.0"]]
 
-  :plugins [[lein-figwheel "0.5.15"]
+  :plugins [[lein-figwheel "0.5.20"]
             [lein-cljsbuild "1.1.7" :exclusions [[org.clojure/clojure]]]]
 
   :source-paths ["src"]


### PR DESCRIPTION
On my machine, `lein figwheel dev` doesn't run successfully. Two dependencies trigger:

```java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter```

Seems like it's [down to Java releases being a bit more modular now](https://stackoverflow.com/a/56786551/2209946). In lieu of adding a CLI flag for the java binary (which I didn't test), updating these dependencies fixes OpenJDK 14.0.1.

This update enables people to continue to enjoy the project ;)